### PR TITLE
[tests-only] added step to update share permission

### DIFF
--- a/src/helpers/sharingHelper.js
+++ b/src/helpers/sharingHelper.js
@@ -485,4 +485,32 @@ module.exports = {
       throw new Error("Invalid Share Type" + lastShare);
     }
   },
+  /**
+   * updates the shared file/folder permission by sharer
+   *
+   * @param shauser
+   * @param resource
+   * @param permissionsreTypeString
+   */
+  updateSharedFilePermissionByUser: async function (
+    sharer,
+    resource,
+    permissions
+  ) {
+    let shareID;
+    const shares = await this.getAllSharesSharedByUser(sharer);
+    for (const shareElement of shares) {
+      if (shareElement.uid_owner === sharer && shareElement.path === resource) {
+        shareID = shareElement.id.toString();
+        break;
+      }
+    }
+    const apiURL = `apps/files_sharing/api/v1/shares/${shareID}`;
+    const body = new URLSearchParams();
+    body.append("permissions", permissions);
+    return httpHelper.putOCS(apiURL, sharer, body.toString()).then((res) => {
+      httpHelper.checkStatus(res, "Could not update share.");
+      return res;
+    });
+  },
 };

--- a/src/stepDefinitions/sharingContext.js
+++ b/src/stepDefinitions/sharingContext.js
@@ -1679,3 +1679,14 @@ Given(
     ]);
   }
 );
+
+Given(
+  "user {string} has updated the share permissions for file/folder {string} to {string}",
+  function (sharer, resource, permissions) {
+    return sharingHelper.updateSharedFilePermissionByUser(
+      sharer,
+      resource,
+      permissions
+    );
+  }
+);


### PR DESCRIPTION
### Description
This PR adds step to update shared file/folder permission.

For example:
  `the user "Alice" has updated permission for shared folder "simple-folder" to "read" permissions`

### Related Issue 
https://github.com/owncloud/client/issues/7423