### PR TITLE
added testing app check and is initialized check

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,9 @@ Given(/^in the server (.*)$/, handler);
 - Since most of the test runner state such as the list of users created by the test runner are stored in the middleware, there is no need to remember them in the test runner itself.
 
 ### Config
+#### Server requirements:
+- `testing` app should be enabled
+
 #### Server specific config variables
 
 | setting | meaning | default |


### PR DESCRIPTION
## Description: 
With this PR:
- check if testing app is enable during `init`
- do not let `execute` and `cleanup` before `init`

## Related Issue:
- part of https://github.com/owncloud/owncloud-test-middleware/issues/25
