### PR TITLE
refactor step for public link share

### DIFF
--- a/src/stepDefinitions/publicLinkContext.js
+++ b/src/stepDefinitions/publicLinkContext.js
@@ -46,7 +46,7 @@ Then('the fields of the last public link share response of user {string} should 
   return sharingHelper.assertUserLastPublicShareDetails(linkCreator, fieldsData)
 })
 
-Then('as user {string} the folder {string} should not have any public link', async function(
+Then('as user {string} the file/folder {string} should not have any public link', async function(
   sharer,
   resource
 ) {


### PR DESCRIPTION
### Description 
This PR refactors step which validates that there is no public link for files/folders.

### Related Issues
https://github.com/owncloud/client/pull/9201