### PR TITLE
[CI] change default branch name to main in .drone.star

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -24,8 +24,9 @@ config = {
 
 trigger = {
 	'ref': [
+		'refs/heads/main',
 		'refs/pull/**',
-		'refs/tags/**'
+		'refs/tags/**',
 	]
 }
 
@@ -245,7 +246,7 @@ def docker(ctx):
 		"steps": buildDockerImage(),
 		"trigger": {
 			"ref": [
-				"refs/heads/master",
+				"refs/heads/main",
 				"refs/tags/**",
 			],
 		},


### PR DESCRIPTION
The triggers for drone were not correct as they used old branch name `master`
This PR changes it to `main`