### PR TITLE
Install core using nodejs14 docker version

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -163,7 +163,7 @@ def installCore(db):
 
 	return [{
 		"name": "install-core",
-		"image": "owncloudci/core",
+		"image": "owncloudci/core:nodejs14",
 		"pull": "always",
 		"settings": {
 			"core_path": "/var/www/owncloud/server",


### PR DESCRIPTION
We `installCore` from a specific core commit. That requires the `owncloudci/core` docker image to clone the `owncloud/core` repo, checkout the commit, and build the software (PHP composer, JS yarn etc).

`owncloudci/core:latest` was just rebuilt today. It is based on `owncloudci/php:7.3` and that no longer has JS tools like `yarn` in it. So CI is failing - see #65 
https://drone.owncloud.com/owncloud/owncloud-test-middleware/166/3/5
```
yarn is not available on your system, please install yarn (npm install -g yarn)
```

This PR uses `owncloudci/core:nodejs14"` which has the JS tools installed.

This is a workaround for this repo for now. `owncloudci/core:latest` should really have the tools available to install any recent core for anywhere - that is its advertised functionality. I will raise an issue about that...