### PR TITLE
Revert "Install core using nodejs14 docker version"

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -163,7 +163,7 @@ def installCore(db):
 
 	return [{
 		"name": "install-core",
-		"image": "owncloudci/core:nodejs14",
+		"image": "owncloudci/core",
 		"pull": "always",
 		"settings": {
 			"core_path": "/var/www/owncloud/server",


### PR DESCRIPTION
This reverts commit aea7b0a383226568e289b92cbc28ab4efdc414ae.

The real problem with `owncloudci/core` docker image should have been fixed by https://github.com/owncloud-ci/core/pull/30