### PR TITLE
Remove try catch from test scripts

### DIFF
--- a/src/gherkin/stepDef.test.js
+++ b/src/gherkin/stepDef.test.js
@@ -264,7 +264,7 @@ describe('Checking stepDef.match matches patterns', () => {
       let stepDef = new StepDef(data.stepDef.token, data.stepDef.pattern, (user, file, sharee) => {
         return 0
       })
-      for (pattern of data.patterns) {
+      for (const pattern of data.patterns) {
         const step = new Step(data.stepDef.token, pattern)
         const res = stepDef.match(step)
         expect(res).toBe(true)
@@ -274,7 +274,7 @@ describe('Checking stepDef.match matches patterns', () => {
       stepDef = new StepDef(data.stepDef.token, data.stepDef.pattern, (user, file) => {
         return 0
       })
-      for (pattern of data.patterns) {
+      for (const pattern of data.patterns) {
         const step = new Step(data.stepDef.token, pattern)
         const res = stepDef.match(step)
         expect(res).toBe(false)
@@ -284,7 +284,7 @@ describe('Checking stepDef.match matches patterns', () => {
       stepDef = new StepDef(data.stepDef.token, data.stepDef.pattern, (user, file) => {
         return 0
       })
-      for (pattern of data.patterns) {
+      for (const pattern of data.patterns) {
         const step = new Step('THEN', pattern)
         const res = stepDef.match(step)
         expect(res).toBe(false)
@@ -294,7 +294,7 @@ describe('Checking stepDef.match matches patterns', () => {
       stepDef = new StepDef(data.stepDef.token, data.stepDef.pattern, (user, file) => {
         return 0
       })
-      for (pattern of data.patterns) {
+      for (const pattern of data.patterns) {
         const step = new Step(data.stepDef.token, pattern, new Table([['test'], ['data']]))
         const res = stepDef.match(step)
         expect(res).toBe(false)
@@ -304,7 +304,7 @@ describe('Checking stepDef.match matches patterns', () => {
       stepDef = new StepDef(data.stepDef.token, data.stepDef.pattern, (user, file) => {
         return 0
       })
-      for (pattern of data.patterns) {
+      for (const pattern of data.patterns) {
         const step = new Step(
           data.stepDef.token,
           pattern + ' some extra text',
@@ -314,14 +314,11 @@ describe('Checking stepDef.match matches patterns', () => {
         expect(res).toBe(false)
       }
     } else {
-      try {
-        const stepDef = new StepDef(data.stepDef.token, data.stepDef.pattern, () => {
+      expect(() => {
+        new StepDef(data.stepDef.token, data.stepDef.pattern, () => {
           return 0
         })
-        throw new Error('creating invalid stepdef should fail but it passed', stepDef)
-      } catch (err) {
-        expect(err.message).toBe(data.errMessage)
-      }
+      }).toThrowError(data.errMessage)
     }
   })
 })

--- a/src/gherkin/testContext.test.js
+++ b/src/gherkin/testContext.test.js
@@ -93,12 +93,9 @@ describe('test testContext', () => {
         return 0
       })
     } else {
-      try {
+      expect(() => {
         testContext.when(Data.pattern, 'abc')
-        throw new Error('Using action of not a function type should fail but it passed.')
-      } catch (err) {
-        expect(err.message).toBe('not function type')
-      }
+      }).toThrowError('not function type')
     }
   })
 
@@ -145,16 +142,11 @@ describe('test testContext', () => {
       return 0
     })
 
-    let errFound
-    try {
+    expect(() => {
       testContext.addstep('GIVEN', 'user {string} has been created', () => {
         return 0
       })
-      throw new Error('adding same step multiple times should fail')
-    } catch (err) {
-      errFound = err
-    }
-    expect(errFound.message).toBe('step already registered')
+    }).toThrowError('step already registered')
   })
 
   it('test given when and then functions', () => {


### PR DESCRIPTION
### Description
This pr removes `try-catch` from test scripts and uses the feature of `expect` to assert thrown errors.

Using `try-catch` for the negative conditions and again throwing errors from the body of try block makes the code look more complex and not cool. Rather we could just use the `.toThrowError` method from `expect` and assert the error messages.
