### PR TITLE
[test-only] Refactor a test step in publicLinkContext

### DIFF
--- a/src/stepDefinitions/publicLinkContext.js
+++ b/src/stepDefinitions/publicLinkContext.js
@@ -38,7 +38,7 @@ Then(
   }
 )
 
-Then('the fields of the last public link share response of user {string} should include', function(
+Then('the last public link share response of user {string} should include following fields', function(
   linkCreator,
   dataTable
 ) {

--- a/src/stepDefinitions/publicLinkContext.js
+++ b/src/stepDefinitions/publicLinkContext.js
@@ -38,7 +38,7 @@ Then(
   }
 )
 
-Then('the last public link share response of user {string} should include following fields', function(
+Then('the last public link share response of user {string} should include the following fields', function(
   linkCreator,
   dataTable
 ) {


### PR DESCRIPTION
This PR refactors a test step so that it can be used in web tests.
This change is necessary because while matching the step from `web` to middleware that uses a data table we match it by using keywords like `following` and `these`. 

The test scenario using that test step fails in the changed step in this PR and the changes made will make it pass https://github.com/owncloud/web/pull/6210