### PR TITLE
Use node 16 to support replaceAll

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -51,7 +51,7 @@ def integrationTests():
 				steps += fixPermissions()
 				steps += [{
 					"name": suite["name"],
-					"image": "owncloudci/nodejs:14",
+					"image": "owncloudci/nodejs:16",
 					"pull": "always",
 					"environment": {
 						"CORE_PATH": "/var/www/owncloud/server",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:16-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
We are getting `Error: TypeError: folderName.replaceAll is not a function`

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll 

Support for `replaceAll` is only from Node.js 15

That code was added in PR #73 - I guess that @SwikritiT has node 15 or 16 locally and did not notice the problem.

IMO we should be able to use the later node 16 here in the middleware - it is an independent thing, not built into either the test runners or the server-under-test.