### PR TITLE
[tests-only]Refactor acceptShare and declineShare function to work on Ocis

### DIFF
--- a/src/helpers/sharingHelper.js
+++ b/src/helpers/sharingHelper.js
@@ -1,5 +1,4 @@
 const httpHelper = require('./httpHelper')
-const { normalize } = require('./path')
 const codify = require('../helpers/codify')
 const assert = require('assert')
 const { client } = require('../config.js')


### PR DESCRIPTION
This PR makes changes to the acceptShare , declineShare function.
These CHanges were necessary because the steps using this function were failing on OCIS in this build: https://drone.owncloud.com/owncloud/web/21808/58/16 
These changes make the tests pass locally