### PR TITLE
Used entrypoint to start the middleware (docker)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ COPY yarn.lock ./
 COPY data ./data
 COPY src ./src
 COPY filesForUpload ./filesForUpload
+COPY dev/entrypoint.sh /entrypoint.sh
 
+RUN chmod +x /entrypoint.sh
 RUN yarn
 
 EXPOSE 3000
 
-CMD [ "npm", "start" ]
+CMD [ "sh", "-c", "/entrypoint.sh" ]

--- a/dev/entrypoint.sh
+++ b/dev/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+# cleanup filesForUpload dir before start
+# upload dir should be available from the shared volume
+rm -rf /uploads/*
+# populate shared volume with the files
+cp -r filesForUpload/* /uploads/
+# start the middleware service
+yarn start


### PR DESCRIPTION
## Description
- populate the shared volume before starting the middleware (docker)
- why don't just use the folder in which files are already present as a shared volume? that's because docker will not sync the already present content of the shared volume dir with the other containers using that same volume. Just an empty folder is created at first. So we've to copy it after the build of the middleware container.

## Motivation
The docker-compose file living `owncloud/web` uses middleware and selenium as services to run web tests on different environments. For the tests involving upload steps, we need to have the files for upload inside the selenium container because the WebUI is running using the browser from the same selenium container. Now, there are two ways to make files available inside the selenium container so that we can upload using the WebUI:
  - upload files to the selenium container using some selenium upload API (tests were using this way before)
  - use the shared volume among middleware and selenium: using this method, we do not have to upload resources to the selenium container. docker will handle this.