### PR TITLE
encode uri for the provisioning urls

### DIFF
--- a/src/stepDefinitions/provisioningContext.js
+++ b/src/stepDefinitions/provisioningContext.js
@@ -124,12 +124,12 @@ async function createUserWithAttributes(
 
 function deleteUser(userId) {
   userSettings.deleteUserFromCreatedUsersList(userId)
-  const url = `cloud/users/${userId}`
+  const url = encodeURI(`cloud/users/${userId}`)
   return httpHelper.deleteOCS(url)
 }
 
 function initUser(userId) {
-  const url = `cloud/users/${userId}`
+  const url = encodeURI(`cloud/users/${userId}`)
   return httpHelper.getOCS(url, userId)
 }
 
@@ -140,7 +140,7 @@ function editUser(userId, key, value) {
   value = encodeURI(value)
   const body = `key=${key}&value=${value}`
 
-  const url = `cloud/users/${userId}`
+  const url = encodeURI(`cloud/users/${userId}`)
   return httpHelper.putOCS(url, userId, body, headers)
 }
 
@@ -171,7 +171,7 @@ function createGroup(groupId) {
  */
 function deleteGroup(groupId) {
   userSettings.deleteGroupFromCreatedGroupsList(groupId)
-  const url = `cloud/groups/${groupId}`
+  const url = encodeURI(`cloud/groups/${groupId}`)
   return httpHelper.deleteOCS(url)
 }
 
@@ -181,12 +181,12 @@ function addToGroup(userId, groupId) {
   }
   const body = new URLSearchParams()
   body.append('groupid', groupId)
-  const url = `cloud/users/${userId}/groups`
+  const url = encodeURI(`cloud/users/${userId}/groups`)
   return httpHelper.postOCS(url, 'admin', body)
 }
 
 function blockUser(userId) {
-  const apiURL = `cloud/users/${userId}/disable`
+  const apiURL = encodeURI(`cloud/users/${userId}/disable`)
   return httpHelper.putOCS(apiURL, 'admin')
 }
 
@@ -230,7 +230,7 @@ Given('the quota of user {string} has been set to {string}', function(userId, qu
   const body = new URLSearchParams()
   body.append('key', 'quota')
   body.append('value', quota)
-  const url = `cloud/users/${userId}`
+  const url = encodeURI(`cloud/users/${userId}`)
   return httpHelper
     .putOCS(url, 'admin', body)
     .then(res => httpHelper.checkStatus(res, 'Could not set quota.'))


### PR DESCRIPTION
### Description
Web tests in ocis recently started failing like this:
```console
Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
    And the administrator has set the default folder for received shares to "Shares" in the server
    And these users have been created with default attributes and without skeleton files in the server:
      │ username │
      │ Alice    │
      │ Brian    │
      │ Carol    │
    Given these groups have been created in the server:
      │ groupname │
      │ <group>   │
    ✖ failed
      Error: TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters
          at new NodeError (node:internal/errors:371:5)
          at new ClientRequest (node:_http_client:154:13)
          at request (node:https:353:10)
          at /usr/src/app/node_modules/node-fetch/lib/index.js:1438:15
          at new Promise (<anonymous>)
          at fetch (/usr/src/app/node_modules/node-fetch/lib/index.js:1407:9)
          at fetcher (/usr/src/app/src/helpers/httpHelper.js:75:35)
          at requestOCSEndpoint (/usr/src/app/src/helpers/httpHelper.js:131:10)
          at Object.deleteOCS (/usr/src/app/src/helpers/httpHelper.js:150:5)
          at deleteGroup (/usr/src/app/src/stepDefinitions/provisioningContext.js:175:21)
          at /var/www/owncloud/web/tests/acceptance/stepDefinitions/middlewareContext.js:38:15
          at runMicrotasks (<anonymous>)
          at processTicksAndRejections (internal/process/task_queues.js:95:5)
    And user "Carol" has created folder "simple-folder" in the server
    - skipped
    And user "Carol" has created file "testimage.jpg" in the server
    - skipped
    And user "Alice" has been added to group "नेपाली" in the server
    - skipped
    And user "Carol" has logged in using the webUI
    - skipped
    When the user shares folder "simple-folder" with group "नेपाली" as "Viewer" using the webUI
    - skipped
    And the user shares file "testimage.jpg" with group "नेपाली" as "Viewer" using the webUI
    - skipped
    And user "Alice" accepts the share "Shares/simple-folder" offered by user "Carol" using the sharing API in the server
    - skipped
    And user "Alice" accepts the share "Shares/testimage.jpg" offered by user "Carol" using the sharing API in the server
    - skipped
    Then group "नेपाली" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
    - skipped
    And group "नेपाली" should be listed as "Viewer" in the collaborators list for file "testimage.jpg" on the webUI
    - skipped
    When the user re-logs in as "Alice" using the webUI
    - skipped
    And the user opens folder "Shares" using the webUI
    - skipped
    Then folder "simple-folder" should be listed on the webUI
    - skipped
```
With this PR, urls are encoded before sending API requests

Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>