### PR TITLE
Creating a user via graph Api

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,6 +139,11 @@ Note: the `testing` app is not available on oCIS. When such steps are used again
 | `LDAP_ADMIN_PASSWORD`  | admin password of the ldap server | admin |
 | `LDAP_BASE_DN` | base DN of the admin server | cn=admin,dc=owncloud,dc=com |
 
+#### Graph Specific config variables
+| setting | meaning | default |
+| -- | -- | -- |
+| `TEST_WITH_GRAPH_API` | use graph api to create users | false |
+
 ### Starting the server
 To start the middleware server change into the checkout directory of owncloud-test-middleware and use the following commands
 ```

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ const withHttp = (url) => (/^https?:\/\//i.test(url) ? url : `http://${url}`)
 
 const RUN_WITH_LDAP = !!process.env.RUN_WITH_LDAP
 const RUN_ON_OCIS = process.env.RUN_ON_OCIS === 'true'
+const RUN_WITH_IDM = process.env.RUN_WITH_IDM === 'true'
 
 const LOCAL_BACKEND_URL = withHttp(
   process.env.BACKEND_HOST || (RUN_ON_OCIS ? 'https://localhost:9200' : 'http://localhost:8080')
@@ -43,6 +44,7 @@ const config = {
     ldap_base_dn: LDAP_BASE_DN,
     testing_data_dir: TESTING_DATA_DIR,
     ldap_password: LDAP_ADMIN_PASSWORD,
+    idm: RUN_WITH_IDM,
   },
   assert,
 }

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ const withHttp = (url) => (/^https?:\/\//i.test(url) ? url : `http://${url}`)
 
 const RUN_WITH_LDAP = !!process.env.RUN_WITH_LDAP
 const RUN_ON_OCIS = process.env.RUN_ON_OCIS === 'true'
-const RUN_WITH_IDM = process.env.RUN_WITH_IDM === 'true'
+const TEST_WITH_GRAPH_API = process.env.TEST_WITH_GRAPH_API === 'true'
 
 const LOCAL_BACKEND_URL = withHttp(
   process.env.BACKEND_HOST || (RUN_ON_OCIS ? 'https://localhost:9200' : 'http://localhost:8080')
@@ -44,7 +44,7 @@ const config = {
     ldap_base_dn: LDAP_BASE_DN,
     testing_data_dir: TESTING_DATA_DIR,
     ldap_password: LDAP_ADMIN_PASSWORD,
-    idm: RUN_WITH_IDM,
+    graph: TEST_WITH_GRAPH_API,
   },
   assert,
 }

--- a/src/helpers/graphHelper.js
+++ b/src/helpers/graphHelper.js
@@ -1,4 +1,5 @@
 const httpHelper = require('./httpHelper')
+const userSettings = require('./userSettings')
 const userHelper = require('./userSettings')
 
 
@@ -18,22 +19,18 @@ exports.createUser = function (
         onPremisesSamAccountName: user,
         passwordProfile: { password }
     })
-
-    console.log('step2 - create')
+    userSettings.addUserToCreatedUsersList(user, password, displayName, email)
     return httpHelper
         .postGraph('users', 'admin', body)
         .then(res => httpHelper.checkStatus(res, 'Failed while creating user'))
 }
 
 exports.deleteUser = function (user) {
-    console.log('step1 - delete')
     return httpHelper
         .deleteGraph(`users/${user}`, 'admin')
-        .then(res => httpHelper.checkStatus(res, 'Failed while deleting user'))
 }
 
 exports.getUser = function (user) {
-    console.log('step3 - init')
     return httpHelper
         .getGraph(`users/${user}`, 'admin')
         .then(res => httpHelper.checkStatus(res, 'user does not found'))

--- a/src/helpers/graphHelper.js
+++ b/src/helpers/graphHelper.js
@@ -2,7 +2,7 @@ const httpHelper = require('./httpHelper')
 const userHelper = require('./userSettings')
 
 
-exports.createUser = async function (
+exports.createUser = function (
     user,
     password = null,
     displayName = null,
@@ -13,10 +13,10 @@ exports.createUser = async function (
     password = password || userHelper.getPasswordForUser(user)
 
     const body = JSON.stringify({
-        'displayName': displayName,
-        'mail': email,
-        'onPremisesSamAccountName': user,
-        'passwordProfile': { 'password': password }
+        displayName,
+        mail: email,
+        onPremisesSamAccountName: user,
+        passwordProfile: { password }
     })
 
     console.log('step2 - create')
@@ -25,14 +25,14 @@ exports.createUser = async function (
         .then(res => httpHelper.checkStatus(res, 'Failed while creating user'))
 }
 
-exports.deleteUser = async function (user) {
+exports.deleteUser = function (user) {
     console.log('step1 - delete')
     return httpHelper
         .deleteGraph(`users/${user}`, 'admin')
         .then(res => httpHelper.checkStatus(res, 'Failed while deleting user'))
 }
 
-exports.getUser = async function (user) {
+exports.getUser = function (user) {
     console.log('step3 - init')
     return httpHelper
         .getGraph(`users/${user}`, 'admin')

--- a/src/helpers/graphHelper.js
+++ b/src/helpers/graphHelper.js
@@ -1,0 +1,40 @@
+const httpHelper = require('./httpHelper')
+const userHelper = require('./userSettings')
+
+
+exports.createUser = async function (
+    user,
+    password = null,
+    displayName = null,
+    email = null
+) {
+    displayName = displayName || userHelper.getDisplayNameForUser(user)
+    email = email || userHelper.getEmailAddressForUser(user)
+    password = password || userHelper.getPasswordForUser(user)
+
+    const body = JSON.stringify({
+        'displayName': displayName,
+        'mail': email,
+        'onPremisesSamAccountName': user,
+        'passwordProfile': { 'password': password }
+    })
+
+    console.log('step2 - create')
+    return httpHelper
+        .postGraph('users', 'admin', body)
+        .then(res => httpHelper.checkStatus(res, 'Failed while creating user'))
+}
+
+exports.deleteUser = async function (user) {
+    console.log('step1 - delete')
+    return httpHelper
+        .deleteGraph(`users/${user}`, 'admin')
+        .then(res => httpHelper.checkStatus(res, 'Failed while deleting user'))
+}
+
+exports.getUser = async function (user) {
+    console.log('step3 - init')
+    return httpHelper
+        .getGraph(`users/${user}`, 'admin')
+        .then(res => httpHelper.checkStatus(res, 'user does not found'))
+}

--- a/src/helpers/httpHelper.js
+++ b/src/helpers/httpHelper.js
@@ -95,6 +95,22 @@ const requestEndpoint = function (path, params, userId = 'admin', header = {}) {
  * @param {string} path
  * @param {object} params
  * @param {string} userId
+ * @param {object} header
+ *
+ * @returns {node-fetch}
+ */
+const requestGraphEndpoint = function (path, params, userId = 'admin', header = {}) {
+  const headers = { ...createAuthHeader(userId), ...header }
+  const options = { ...params, headers }
+  const url = join(backendHelper.getCurrentBackendUrl(), 'graph/v1.0', path)
+  return fetcher(url, options)
+}
+
+/**
+ *
+ * @param {string} path
+ * @param {object} params
+ * @param {string} userId
  * @param {string} pass
  * @param {object} headers
  *
@@ -164,5 +180,12 @@ module.exports = {
   proppatch: (url, userId, body, header) =>
     requestEndpoint(url, { body, method: 'PROPPATCH' }, userId, header),
   lock: (url, userId, body, header) =>
-      requestEndpoint(url, { body, method: 'LOCK' }, userId, header)
+    requestEndpoint(url, { body, method: 'LOCK' }, userId, header),
+  // graph Api requests
+  postGraph: (url, userId, body, header) =>
+    requestGraphEndpoint(url, { body, method: 'POST' }, userId, header),
+  deleteGraph: (url, userId, body, header) =>
+    requestGraphEndpoint(url, { body, method: 'DELETE' }, userId, header),
+  getGraph: (url, userId, body, header) =>
+    requestGraphEndpoint(url, { body, method: 'GET' }, userId, header),
 }

--- a/src/stepDefinitions/provisioningContext.js
+++ b/src/stepDefinitions/provisioningContext.js
@@ -19,7 +19,7 @@ function createDefaultUser(userId, skeletonType) {
   const email = userSettings.getEmailAddressOfDefaultUser(userId)
   if (client.globals.ldap) {
     return ldap.createUser(client.globals.ldapClient, userId)
-  } else if (client.globals.idm) {
+  } else if (client.globals.graph) {
     return graph.createUser(userId, password, displayname, email)
   }
   return createUser(userId, password, displayname, email, skeletonType)
@@ -126,7 +126,7 @@ async function createUserWithAttributes(
 
 function deleteUser(userId) {
   userSettings.deleteUserFromCreatedUsersList(userId)
-  if (client.globals.idm) {
+  if (client.globals.graph) {
     return graph.deleteUser(userId)
   } else {
     const url = encodeURI(`cloud/users/${userId}`)
@@ -135,7 +135,7 @@ function deleteUser(userId) {
 }
 
 function initUser(userId) {
-  if (client.globals.idm) {
+  if (client.globals.graph) {
     return graph.getUser(userId)
   } else {
     const url = encodeURI(`cloud/users/${userId}`)

--- a/src/stepDefinitions/provisioningContext.js
+++ b/src/stepDefinitions/provisioningContext.js
@@ -19,8 +19,7 @@ function createDefaultUser(userId, skeletonType) {
   const email = userSettings.getEmailAddressOfDefaultUser(userId)
   if (client.globals.ldap) {
     return ldap.createUser(client.globals.ldapClient, userId)
-  }
-  else if (client.globals.idm) {
+  } else if (client.globals.idm) {
     return graph.createUser(userId, password, displayname, email)
   }
   return createUser(userId, password, displayname, email, skeletonType)

--- a/src/stepDefinitions/provisioningContext.js
+++ b/src/stepDefinitions/provisioningContext.js
@@ -9,6 +9,7 @@ const codify = require('../helpers/codify')
 const httpHelper = require('../helpers/httpHelper')
 const ldap = require('../helpers/ldapHelper')
 const userSettings = require('../helpers/userSettings')
+const graph = require('../helpers/graphHelper')
 const sharingHelper = require('../helpers/sharingHelper')
 const { setConfigs, getActualSkeletonDir } = require('../helpers/config')
 
@@ -18,6 +19,9 @@ function createDefaultUser(userId, skeletonType) {
   const email = userSettings.getEmailAddressOfDefaultUser(userId)
   if (client.globals.ldap) {
     return ldap.createUser(client.globals.ldapClient, userId)
+  }
+  else if (client.globals.idm) {
+    return graph.createUser(userId, password, displayname, email)
   }
   return createUser(userId, password, displayname, email, skeletonType)
 }
@@ -128,8 +132,12 @@ function deleteUser(userId) {
 }
 
 function initUser(userId) {
-  const url = encodeURI(`cloud/users/${userId}`)
-  return httpHelper.getOCS(url, userId)
+  if (client.globals.idm) {
+    return graph.getUser(userId)
+  } else {
+    const url = encodeURI(`cloud/users/${userId}`)
+    return httpHelper.getOCS(url, userId)
+  }
 }
 
 function editUser(userId, key, value) {

--- a/src/stepDefinitions/provisioningContext.js
+++ b/src/stepDefinitions/provisioningContext.js
@@ -126,8 +126,12 @@ async function createUserWithAttributes(
 
 function deleteUser(userId) {
   userSettings.deleteUserFromCreatedUsersList(userId)
-  const url = encodeURI(`cloud/users/${userId}`)
-  return httpHelper.deleteOCS(url)
+  if (client.globals.idm) {
+    return graph.deleteUser(userId)
+  } else {
+    const url = encodeURI(`cloud/users/${userId}`)
+    return httpHelper.deleteOCS(url)
+  }
 }
 
 function initUser(userId) {


### PR DESCRIPTION
### To unlock CI in ocis (webUITest failed), I need to switch the methods user creation  in midleware:

`Given user "Alice" has been created with default attributes and without skeleton files in the server`
and
`Given these users have been created with default attributes and without skeleton files in the server:`
to graphApi



#### How tested:
- start ocis with idm by default - branch https://github.com/owncloud/ocis/pull/3331
- start middleware with IDM variable: `BACKEND_HOST=https://localhost:9200 NODE_TLS_REJECT_UNAUTHORIZED=0 RUN_ON_OCIS=true TEST_WITH_GRAPH_API yarn start`
- init middleware: `curl -XPOST http://localhost:3000/init`
- try to create user "Alice": `curl -XPOST http://localhost:3000/execute -d '{"step": "Given user \"Alice\" has been created with default attributes and without skeleton files"}' -H "Content-Type: application/json"`

Result: Alice should be created: `curl  -k -u admin:admin https://localhost:9200/graph/v1.0/users/Alice`


