### PR TITLE
Added changelog for v1.6.0 and bumped version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Changelog for [1.6.0] (2022-4-29)
+The following sections list the changes for 1.6.0
+
+[1.6.0]: https://github.com/owncloud/owncloud-test-middleware/compare/v1.5.0...v1.6.0
+
+### Summary
+- Creating group and adding member to group via GraphApi by @ScharfViktor in https://github.com/owncloud/owncloud-test-middleware/pull/113
+
 ## Changelog for [1.5.0] (2022-4-27)
 The following sections list the changes for 1.5.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middleware",
-  "version": "1.5.0",
+  "version": "1.4.0",
   "description": "A test middleware for owncloud clients",
   "main": "index.js",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "middleware",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "description": "A test middleware for owncloud clients",
   "main": "index.js",
   "keywords": [],


### PR DESCRIPTION
## Description
- bump version to v1.6.0
- add changelog for v1.6.0
## Related
- Part of https://github.com/owncloud/owncloud-test-middleware/issues/114