### PR TITLE
[tests-only]Test for depth `1` instead of instead of `infinty`

### DIFF
--- a/src/helpers/webdavHelper.js
+++ b/src/helpers/webdavHelper.js
@@ -134,7 +134,7 @@ exports.propfind = function (path, userId, properties, folderDepth = '1') {
  * @param {string} user
  * @param depth
  */
-exports.getTrashBinElements = function (user, depth = 'infinity') {
+exports.getTrashBinElements = function (user, depth = '1') {
   return new Promise((resolve, reject) => {
     exports
         .propfind(


### PR DESCRIPTION
### Description

This PR changes the depth infinity used in middleware to `1` as OC 10.10 by default does not allow to request depth=infinity in PROPFIND and also to check if web tests uses depth `0 or 1` 
Part of this issue : https://github.com/owncloud/web/issues/7029