### PR TITLE
[tests-only]Refactor occ related step for ocis

### DIFF
--- a/src/helpers/occHelper.js
+++ b/src/helpers/occHelper.js
@@ -1,4 +1,5 @@
 const httpHelper = require('../helpers/httpHelper')
+const { client } = require('../config')
 
 /**
  * Run occ command using the testing API
@@ -6,6 +7,9 @@ const httpHelper = require('../helpers/httpHelper')
  * @param {Array} args
  */
 exports.runOcc = function (args) {
+  if (client.globals.ocis) {
+    return
+  }
   const params = new URLSearchParams()
   params.append('command', args.join(' '))
   const apiURL = 'apps/testing/api/v1/occ'

--- a/src/stepDefinitions/generalContext.js
+++ b/src/stepDefinitions/generalContext.js
@@ -11,10 +11,6 @@ Given('the setting {string} of app {string} has been set to {string}', function(
   app,
   value
 ) {
-  if (client.globals.ocis) {
-    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
-    return
-  }
   return occHelper.runOcc(['config:app:set', app, setting, '--value=' + value])
 })
 
@@ -32,18 +28,10 @@ Given('the setting {string} of app {string} has been set to {string} on remote s
 })
 
 Given('the administrator has cleared the versions for user {string}', function(userId) {
-  if (client.globals.ocis) {
-    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
-    return
-  }
   return occHelper.runOcc(['versions:cleanup', userId])
 })
 
 Given('the administrator has cleared the versions for all users', function() {
-  if (client.globals.ocis) {
-    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
-    return
-  }
   return occHelper.runOcc(['versions:cleanup'])
 })
 
@@ -84,18 +72,10 @@ After(async function(testCase) {
 // })
 
 Given('the app {string} has been disabled', function(app) {
-  if (client.globals.ocis) {
-    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
-    return
-  }
   return occHelper.runOcc(['app:disable', app])
 })
 
 Given('default expiration date for users is set to {int} day/days', function(days) {
-  if (client.globals.ocis) {
-    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
-    return
-  }
   occHelper.runOcc([`config:app:set --value ${days} core shareapi_expire_after_n_days_user_share`])
 
   return this

--- a/src/stepDefinitions/sharingContext.js
+++ b/src/stepDefinitions/sharingContext.js
@@ -286,10 +286,16 @@ Given(
 )
 
 Given('the administrator has enabled exclude groups from sharing', function() {
+  if (client.globals.ocis) {
+    return
+  }
   return runOcc(['config:app:set core shareapi_exclude_groups --value=yes'])
 })
 
 Given('the administrator has excluded group {string} from sharing', async function(group) {
+  if (client.globals.ocis) {
+    return
+  }
   const configList = await runOcc(['config:list'])
   const config = _.get(configList, 'ocs.data.stdOut')
   const configParsed = JSON.parse(config)
@@ -312,6 +318,9 @@ Given('the administrator has excluded group {string} from sharing', async functi
 Given(
   'the administrator has set the minimum characters for sharing autocomplete to {string}',
   function(value) {
+    if (client.globals.ocis) {
+      return
+    }
     return runOcc(['config:system:set user.search_min_length --value=' + value])
   }
 )
@@ -324,6 +333,9 @@ Given('user {string} has created a public link with following settings', functio
 })
 
 Given('the administrator has excluded group {string} from receiving shares', async function(group) {
+  if (client.globals.ocis) {
+    return
+  }
   const configList = await runOcc(['config:list'])
   const config = _.get(configList, 'ocs.data.stdOut')
   const configParsed = JSON.parse(config)

--- a/src/stepDefinitions/sharingContext.js
+++ b/src/stepDefinitions/sharingContext.js
@@ -286,16 +286,10 @@ Given(
 )
 
 Given('the administrator has enabled exclude groups from sharing', function() {
-  if (client.globals.ocis) {
-    return
-  }
   return runOcc(['config:app:set core shareapi_exclude_groups --value=yes'])
 })
 
 Given('the administrator has excluded group {string} from sharing', async function(group) {
-  if (client.globals.ocis) {
-    return
-  }
   const configList = await runOcc(['config:list'])
   const config = _.get(configList, 'ocs.data.stdOut')
   const configParsed = JSON.parse(config)
@@ -318,9 +312,6 @@ Given('the administrator has excluded group {string} from sharing', async functi
 Given(
   'the administrator has set the minimum characters for sharing autocomplete to {string}',
   function(value) {
-    if (client.globals.ocis) {
-      return
-    }
     return runOcc(['config:system:set user.search_min_length --value=' + value])
   }
 )
@@ -333,9 +324,6 @@ Given('user {string} has created a public link with following settings', functio
 })
 
 Given('the administrator has excluded group {string} from receiving shares', async function(group) {
-  if (client.globals.ocis) {
-    return
-  }
   const configList = await runOcc(['config:list'])
   const config = _.get(configList, 'ocs.data.stdOut')
   const configParsed = JSON.parse(config)


### PR DESCRIPTION
This PR refactor occ a related step for ocis to return. occ command in oC10 is used to set system-wide settings in oC10. Many of those things may be implemented in oCIS, but the way that the system-wide setting is done by the system administrator in oCIS will be different. Steps running occ command should be refactored for ocis.

Related issue: https://github.com/owncloud/owncloud-test-middleware/issues/123