### PR TITLE
Strip time from expiration date

### DIFF
--- a/src/helpers/sharingHelper.js
+++ b/src/helpers/sharingHelper.js
@@ -72,8 +72,7 @@ module.exports = {
         '-' +
         String(date.getMonth() + 1).padStart(2, '0') +
         '-' +
-        String(date.getDate()).padStart(2, '0') +
-        ' 00:00:00'
+        String(date.getDate()).padStart(2, '0')
     }
     return dateString
   },
@@ -129,6 +128,7 @@ module.exports = {
                 .toString()
             } else if (expectedDetail.field === 'expiration') {
               expectedDetail.value = sharingHelper.calculateDate(expectedDetail.value)
+              share[expectedDetail.field] = share[expectedDetail.field].toString().split(' ')[0]
             }
 
             if (


### PR DESCRIPTION
> The expiry date should just be a date 2023-01-07. Expiry time is not supported. When the test code for the Given step calculates +10 days, it needs to just get the date, and not append any time.

https://github.com/owncloud/web/pull/8159#issuecomment-1366573099