### PR TITLE
feat: retry webdav download on 425 status code

### DIFF
--- a/src/helpers/webdavHelper.js
+++ b/src/helpers/webdavHelper.js
@@ -32,7 +32,7 @@ exports.download = async function (userId, file) {
   if ([423, 425].includes(res.status)) {
     if (res.status === 423) {
       console.info('Resource is locked. Retrying...')
-    } else if(res.status === 425) {
+    } else if (res.status === 425) {
       console.info('Resource is in postprocessing. Retrying...')
     }
     res = await new Promise((resolve) => {

--- a/src/helpers/webdavHelper.js
+++ b/src/helpers/webdavHelper.js
@@ -28,9 +28,13 @@ exports.download = async function (userId, file) {
   const davPath = exports.createDavPath(userId, file)
   let res = await httpHelper.get(davPath, userId)
 
-  // wait for 500ms and retry download if the resource is locked
-  if (res.status === 423) {
-    console.info('Resource is locked. Retrying...')
+  // wait for 500ms and retry download if the resource is locked or in postprocessing
+  if ([423, 425].includes(res.status)) {
+    if (res.status === 423) {
+      console.info('Resource is locked. Retrying...')
+    } else if(res.status === 425) {
+      console.info('Resource is in postprocessing. Retrying...')
+    }
     res = await new Promise((resolve) => {
       setTimeout(async () => {
         resolve(await httpHelper.get(davPath, userId))


### PR DESCRIPTION
The oCIS backend may return a 425 status code when a file is still in postprocessing state. Retry behaviour should then be the same as for 423 locked.