### PR TITLE
fix: Make webdavContext.getResourceType more resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Changelog for [1.8.8] (2023-12-06)
+The following sections list the changes for 1.8.8
+
+[1.8.8]: https://github.com/owncloud/owncloud-test-middleware/compare/v1.8.7...v1.8.8
+
+### Summary
+- Make webdavContext.getResourceType more resilient @dschmidt in https://github.com/owncloud/owncloud-test-middleware/pull/142
+
 ## Changelog for [1.8.7] (2023-11-16)
 The following sections list the changes for 1.8.7
 

--- a/src/stepDefinitions/webdavContext.js
+++ b/src/stepDefinitions/webdavContext.js
@@ -49,16 +49,24 @@ const fileShouldNotHaveContent = async function(userId, file, content) {
 }
 
 const getResourceType = function(data) {
-  let resourceType
-
   const result = xml2js(data, { compact: true })
   const responses = _.get(result, 'd:multistatus.d:response')
+  let response
   if (responses instanceof Array) {
-    resourceType = _.get(responses[0], 'd:propstat.d:prop.d:resourcetype')
+    response = responses[0]
   } else {
-    resourceType = _.get(responses, 'd:propstat.d:prop.d:resourcetype')
+    response = responses
   }
 
+  const propstats = response['d:propstat']
+  let propstat
+  if (propstats instanceof Array) {
+    propstat = propstats[0]
+  } else {
+    propstat = propstats
+  }
+
+  const resourceType = _.get(propstat, 'd:prop.d:resourcetype')
   if (Object.keys(resourceType)[0] === 'd:collection') {
     return 'folder'
   } else {


### PR DESCRIPTION
The old implementation failed when there was a second d:propstat object in the d:response (which happens when a not found prop is added)

Should fix failure in https://github.com/owncloud/ocis/pull/7898