### PR TITLE
Revert "delete share permission"

### DIFF
--- a/src/helpers/sharingHelper.js
+++ b/src/helpers/sharingHelper.js
@@ -16,14 +16,15 @@ module.exports = {
     update: 2,
     create: 4,
     delete: 8,
-    all: 15,
+    share: 16,
+    all: 31,
   }),
   SHARE_STATE: Object.freeze({
     accepted: 0,
     pending: 1,
     declined: 2,
   }),
-  COLLABORATOR_PERMISSION_ARRAY: ['update', 'create', 'delete'],
+  COLLABORATOR_PERMISSION_ARRAY: ['share', 'update', 'create', 'delete'],
   /**
    *
    * @param permissionsString string of permissions separated by comma. For valid permissions see this.PERMISSION_TYPES


### PR DESCRIPTION
middleware is no longer used in ocis 
Reverts owncloud/owncloud-test-middleware#143

@saw-jan I guess after merging this PR we can just delete last release? 
<img width="1394" alt="Screenshot 2024-05-18 at 12 57 32" src="https://github.com/owncloud/owncloud-test-middleware/assets/84779829/544246ee-ed1f-4f42-96d9-8fcfdfdb9f79">
